### PR TITLE
Update README.md ot use `webTokenProvider`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Initialize the plugin and provide it as an extension to the SDK that you want to
 ``` java 
 TrustedIdentityPropagationPlugin trustedIdentityPropagationPlugin = TrustedIdentityPropagationPlugin.builder()
             .stsClient(client)
-            .idTokenSupplier(() -> idToken)
+            .webTokenProvider(() -> idToken)
             .applicationArn(idcApplicationArn)
             .accessRoleArn(AccessRoleArn)
             .ssoOidcClient(SsoOidcClient.builder().region(Region.US_EAST_1).build())


### PR DESCRIPTION
*Description of changes:* 
Our Builder interface has methods named both `webTokenProvider()` and `idTokenSupplier()`, which both internally update the `webTokenProvider` property. Updating our documentation to use the more general named `webTokenProvider()` method since it matches the property's name.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
