### PR TITLE
Remove SNAPSHOT from version artifact.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>software.amazon.awsidentity.trustedIdentityPropagation</groupId>
   <artifactId>aws-sdk-java-trustedIdentityPropagation-java-plugin</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0</version>
 
   <properties>
     <service.id>awsidentity</service.id>


### PR DESCRIPTION
Having `-SNAPSHOT` as the version suffix will require users to enable access to maven snapshot repository in their own project. Removing the suffix for better user experience.
