### PR TITLE
Update the logic with applicationRole arn usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,6 @@ jobs:
           java-version: '21'
           cache: 'maven'
       - name: Build with Maven
+        env:
+          AWS_REGION: "us-east-1"
         run: mvn clean package --file pom.xml

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ StsClient stsClient =
 
 ```
 
+Please refer to the [TIP Plugin documentation](https://docs.aws.amazon.com/sdkref/latest/guide/access-tip.html) for input parameters details.
+
 ## Install from source
 
 The plugin has been published to Maven and can be installed as described above. If you want to play with the latest version, you can build from source as follows.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>software.amazon.awsidentity.trustedIdentityPropagation</groupId>
   <artifactId>aws-sdk-java-trustedIdentityPropagation-java-plugin</artifactId>
-  <version>1.0.0</version>
+  <version>2.0.0</version>
 
   <properties>
     <service.id>awsidentity</service.id>

--- a/src/main/java/software/amazon/awssdk/trustedidentitypropagation/TrustedIdentityPropagationPlugin.java
+++ b/src/main/java/software/amazon/awssdk/trustedidentitypropagation/TrustedIdentityPropagationPlugin.java
@@ -90,6 +90,8 @@ public class TrustedIdentityPropagationPlugin implements SdkPlugin,
      */
     private final String applicationRoleArn;
 
+    private IdentityProvider webIdentityCredentialsProvider;
+
     private TrustedIdentityPropagationPlugin(Builder builder) {
 
         Validate.notNull(builder.applicationArn, "Application Arn must be provided.");
@@ -103,6 +105,14 @@ public class TrustedIdentityPropagationPlugin implements SdkPlugin,
         this.webTokenProvider = builder.webTokenProvider;
         this.applicationRoleArn = builder.applicationRoleArn;
 
+        if (builder.ssoOidcClient == null || builder.stsClient == null) {
+            Validate.notNull(builder.applicationRoleArn,
+                    "Either both of ssoOidcClient and stsClient OR the application role must be provided.");
+            Validate.isFalse(builder.accessRoleArn.equals(builder.applicationRoleArn),
+                    "Access Role and Application Role can not be same as it leads to self role assumption.");
+            retrieveCredentialsWithWebIdentityProvider();
+        }
+
         this.ssoOidcClient = Validate.getOrDefault(builder.ssoOidcClient,
             getSsoOidcClientSupplier());
 
@@ -111,12 +121,7 @@ public class TrustedIdentityPropagationPlugin implements SdkPlugin,
     }
 
     private Supplier<StsClient> getStsClientSupplier() {
-        return () -> {
-            StsClient client = StsClient.builder()
-                .credentialsProvider(AnonymousCredentialsProvider.create()).build();
-            resourcesToClose.add(client);
-            return client;
-        };
+        return () -> getStsClient();
     }
 
     private Supplier<SsoOidcClient> getSsoOidcClientSupplier() {
@@ -124,25 +129,36 @@ public class TrustedIdentityPropagationPlugin implements SdkPlugin,
     }
 
     private SsoOidcClient getSsoOidcClient() {
+        SsoOidcClient client = SsoOidcClient.builder()
+            .credentialsProvider(webIdentityCredentialsProvider).build();
+
+        resourcesToClose.add(client);
+        return client;
+    }
+
+    private StsClient getStsClient() {
+        StsClient client = StsClient.builder()
+            .credentialsProvider(webIdentityCredentialsProvider).build();
+
+        resourcesToClose.add(client);
+        return client;
+    }
+
+    private void retrieveCredentialsWithWebIdentityProvider() {
         StsClient noAuthStsClient = StsClient.builder()
             .credentialsProvider(AnonymousCredentialsProvider.create()).build();
-        IdentityProvider credentialsProvider =
+        webIdentityCredentialsProvider =
             StsAssumeRoleWithWebIdentityCredentialsProvider.builder()
                 .stsClient(noAuthStsClient)
                 .refreshRequest(
                     AssumeRoleWithWebIdentityRequest.builder()
                         .webIdentityToken(webTokenProvider.get())
-                        .roleArn(
-                            applicationRoleArn != null ? applicationRoleArn : accessRoleArn)
+                        .roleArn(applicationRoleArn)
                         .roleSessionName(getBootstrapSessionName(applicationArn)).build())
                 .build();
-        SsoOidcClient client = SsoOidcClient.builder()
-            .credentialsProvider(credentialsProvider).build();
-        resourcesToClose.add(noAuthStsClient);
-        resourcesToClose.add(client);
-        return client;
-    }
 
+        resourcesToClose.add(noAuthStsClient);
+    }
 
     public static TrustedIdentityPropagationPlugin create() {
         return new TrustedIdentityPropagationPlugin(builder());
@@ -215,11 +231,6 @@ public class TrustedIdentityPropagationPlugin implements SdkPlugin,
 
         public Builder applicationRoleArn(String applicationRoleArn) {
             this.applicationRoleArn = applicationRoleArn;
-            return this;
-        }
-
-        public Builder idTokenSupplier(Supplier<String> idTokenSupplier) {
-            this.webTokenProvider = idTokenSupplier;
             return this;
         }
 

--- a/src/main/java/software/amazon/awssdk/trustedidentitypropagation/internal/IdentityAwareCredentialsProvider.java
+++ b/src/main/java/software/amazon/awssdk/trustedidentitypropagation/internal/IdentityAwareCredentialsProvider.java
@@ -94,9 +94,7 @@ public class IdentityAwareCredentialsProvider implements AwsCredentialsProvider 
             .roleArn(accessRoleArn)
             .durationSeconds(FIFTEEN_MINUTES_IN_SEC)
             .roleSessionName(getIdentityEnhancedSessionName(applicationArn))
-            .overrideConfiguration(
-                c -> c.credentialsProvider(ssoOidcClient.serviceClientConfiguration()
-                    .credentialsProvider()).addApiName(getTipApiName()))
+            .overrideConfiguration(c -> c.addApiName(getTipApiName()))
             .providedContexts(ProvidedContext.builder()
                 .providerArn(CONTEXT_PROVIDER_IDENTITY_CENTER)
                 .contextAssertion(contextAssertion)

--- a/src/test/java/software/amazon/awssdk/trustedidentitypropagation/TrustedIdentityPropagationPluginIntegrationTests.java
+++ b/src/test/java/software/amazon/awssdk/trustedidentitypropagation/TrustedIdentityPropagationPluginIntegrationTests.java
@@ -31,7 +31,7 @@ public class TrustedIdentityPropagationPluginIntegrationTests {
 
         TrustedIdentityPropagationPlugin trustedIdentityPropagationPlugin = TrustedIdentityPropagationPlugin.builder()
             .stsClient(client)
-            .idTokenSupplier(() -> idToken)
+            .webTokenProvider(() -> idToken)
             .applicationArn(idcApplicationArn)
             .accessRoleArn(AccessRoleArn)
             .ssoOidcClient(SsoOidcClient.builder().region(Region.US_EAST_1).build())
@@ -56,13 +56,9 @@ public class TrustedIdentityPropagationPluginIntegrationTests {
         String idcApplicationArn = envMap.get("IdcApplicationArn");
         String AccessRoleArn = envMap.get("AccessRoleArn");
 
-        StsClient client = StsClient.builder()
-            .region(Region.US_EAST_1)
-            .credentialsProvider(AnonymousCredentialsProvider.create()).build();
-
         TrustedIdentityPropagationPlugin trustedIdentityPropagationPlugin = TrustedIdentityPropagationPlugin.builder()
-            .stsClient(client)
-            .idTokenSupplier(() -> idToken)
+            .stsClient(StsClient.builder().region(Region.US_EAST_1).build())
+            .webTokenProvider(() -> idToken)
             .applicationArn(idcApplicationArn)
             .accessRoleArn(AccessRoleArn)
             .ssoOidcClient(SsoOidcClient.builder().region(Region.US_EAST_1).build())

--- a/src/test/java/software/amazon/awssdk/trustedidentitypropagation/TrustedIdentityPropagationPluginTest.java
+++ b/src/test/java/software/amazon/awssdk/trustedidentitypropagation/TrustedIdentityPropagationPluginTest.java
@@ -3,6 +3,7 @@ package software.amazon.awssdk.trustedidentitypropagation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.AfterEach;
@@ -28,11 +29,12 @@ public class TrustedIdentityPropagationPluginTest {
     private String idcIdToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZ"
         + "SI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJzdHM6aWRlbnRpdHlfY29udGV4dCI6ImlkY29udGV4dCJ9.5vKibdvG2tmtmRtmgUaXcbSIkLwP67h6oIyVMBwPt1Q";
     private String roleArn = "arn:aws:iam::123456789101:role/example";
+    private String applicationRoleArn = "arn:aws:iam::123456789101:role/applicationRoleExample";
     private String ssoClientId = "arn:aws:sso::123456789101:application/ssoins-1234567891234567/apl-1234567891234567";
     private StsClient stsClient = Mockito.mock(StsClient.class);
     private SsoOidcClient oidcClient = Mockito.mock(SsoOidcClient.class);
     private TrustedIdentityPropagationPlugin trustedIdentityPropagationPlugin = TrustedIdentityPropagationPlugin.builder()
-        .idTokenSupplier(() -> idToken)
+        .webTokenProvider(() -> idToken)
         .applicationArn(ssoClientId)
         .accessRoleArn(roleArn)
         .stsClient(stsClient)
@@ -83,13 +85,54 @@ public class TrustedIdentityPropagationPluginTest {
             .build()).isInstanceOfAny(RuntimeException.class);
 
         assertThatThrownBy(() -> TrustedIdentityPropagationPlugin.builder()
-            .idTokenSupplier(() -> idToken)
+            .webTokenProvider(() -> idToken)
             .accessRoleArn(roleArn)
             .build()).isInstanceOfAny(RuntimeException.class);
 
         assertThatThrownBy(() -> TrustedIdentityPropagationPlugin.builder()
-            .idTokenSupplier(() -> idToken)
+            .webTokenProvider(() -> idToken)
             .applicationArn(ssoClientId)
             .build()).isInstanceOfAny(RuntimeException.class);
+
+        assertThatThrownBy(() -> TrustedIdentityPropagationPlugin.builder()
+            .webTokenProvider(() -> idToken)
+            .applicationArn(ssoClientId)
+            .accessRoleArn(roleArn)
+            .build()).isInstanceOfAny(RuntimeException.class);
+
+        assertThatThrownBy(() -> TrustedIdentityPropagationPlugin.builder()
+                .webTokenProvider(() -> idToken)
+                .applicationArn(ssoClientId)
+                .accessRoleArn(roleArn)
+                .ssoOidcClient(oidcClient)
+                .build()).isInstanceOfAny(RuntimeException.class);
+
+        assertThatThrownBy(() -> TrustedIdentityPropagationPlugin.builder()
+                .webTokenProvider(() -> idToken)
+                .applicationArn(ssoClientId)
+                .accessRoleArn(roleArn)
+                .stsClient(stsClient)
+                .build()).isInstanceOfAny(RuntimeException.class);
+    }
+
+    @Test
+    public void tipPlugin_doesNotThrowWhenOidcAndStsClientsAreProvided() {
+        assertDoesNotThrow(() -> TrustedIdentityPropagationPlugin.builder()
+            .webTokenProvider(() -> idToken)
+            .applicationArn(ssoClientId)
+            .accessRoleArn(roleArn)
+            .stsClient(stsClient)
+            .ssoOidcClient(oidcClient)
+            .build());
+    }
+
+    @Test
+    public void tipPlugin_doesNotThrowWhenApplicationRoleArnIsProvided() {
+        assertDoesNotThrow(() -> TrustedIdentityPropagationPlugin.builder()
+            .webTokenProvider(() -> idToken)
+            .applicationArn(ssoClientId)
+            .accessRoleArn(roleArn)
+            .applicationRoleArn(applicationRoleArn)
+            .build());
     }
 }


### PR DESCRIPTION
**Description of changes:**
Update the applicationRoleArn parameter requirements and create a new major version with the following changes:
Make either `ssoOidcClient` or `applicationRoleArn` required, the provided parameter reflects the client's intention as to whether they want to use existing credentials (e.g. default credentials) or use the applicationRole for `sso-oauth:CreateTokenWithIAM` and `sts:AssumeRole` permissions.
- If `ssoOidcClient` is provided, use the credentials on it for `sso & sts` access
- otherwise,  make `applicationRoleArn` mandatory and make sure it's not same as `accessRole` in order to avoid self-role assumption
- 
**Testing**
- Unit Tests
- Manual tests with Idc test application setup with S3AccessGrants